### PR TITLE
Antivirals: use risk ratios and updated math

### DIFF
--- a/wasm_dynode/src/model.rs
+++ b/wasm_dynode/src/model.rs
@@ -267,7 +267,6 @@ impl<const N: usize> System<f64, State<N>> for &SEIRModel<N> {
         // Deaths
         let dto_pre_d = dat_risk
             .component_mul(&self.parameters.fraction_dead)
-            .component_mul(&self.ave.rr_p_hosp)
             .component_mul(&self.ave.rr_p_death);
 
         let dpre_d_to_d_cum = pre_d / self.parameters.death_delay;


### PR DESCRIPTION
- Rather than efficacy, use the risk ratios $1 - \mathrm{AVE}$, which mostly avoids the `.map(|x| 1.0 - x)` construct
- Use clearer naming about the risk ratios and what they protect against
- Rewrite `i_effective` as per equation in #23, which I hope is clearer

`cargo test` passes, except for complaints about `#![feature]`, which I think means that this is producing the same results as in #27 