### PR TITLE
Update community mitigations

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -154,6 +154,6 @@ Define the parameters:
 
 - $t_\mathrm{start}$: time that the mitigation starts
 - $\Delta t_\mathrm{duration}$: duration of the mitigation
-- $\mathrm{ContactMult}$: proportional change in contact rate, assumed constant over the duration and equal for all age groups
+- $\mathrm{Eff}$: effectivness  of the mitigation (i.e., risk ratio in contact rate), assumed constant over the duration and equal for all age groups
 
-During the period from $t_\mathrm{start}$ to $t_\mathrm{start} + \Delta t_\mathrm{duration}$, adjust the contact matrix entries from $C_{ij}$ to $\mathrm{ContactMult} \times C_{ij}$.
+During the period from $t_\mathrm{start}$ to $t_\mathrm{start} + \Delta t_\mathrm{duration}$, adjust the contact matrix entries from $C_{ij}$ to $(1 - \mathrm{Eff}) \times C_{ij}$.

--- a/docs/index.md
+++ b/docs/index.md
@@ -145,3 +145,15 @@ The number of outcomes is:
 \dot{D}^\mathrm{cum}_i &= \dot{H}^\mathrm{pre} \times \frac{1}{T_D^\mathrm{pre}}
 \end{align*}
 ```
+
+## Mitigations
+
+### Community mitigation
+
+Define the parameters:
+
+- $t_\mathrm{start}$: time that the mitigation starts
+- $\Delta t_\mathrm{duration}$: duration of the mitigation
+- $\mathrm{ContactMult}$: proportional change in contact rate, assumed constant over the duration and equal for all age groups
+
+During the period from $t_\mathrm{start}$ to $t_\mathrm{start} + \Delta t_\mathrm{duration}$, adjust the contact matrix entries from $C_{ij}$ to $\mathrm{ContactMult} \times C_{ij}$.

--- a/docs/index.md
+++ b/docs/index.md
@@ -148,7 +148,7 @@ The number of outcomes is:
 
 ## Mitigations
 
-### Community mitigation
+### Community mitigations
 
 Define the parameters:
 

--- a/src/mitigations/Community.tsx
+++ b/src/mitigations/Community.tsx
@@ -6,7 +6,7 @@ import { useDays, useMitigation, useParams } from "../ModelState";
 import { CommunityMitigationParamsExport } from "@wasm/wasm_dynode";
 
 export function CommunityEditor() {
-    let [{ start, duration, contact_multiplier }, updateParams] =
+    let [{ start, duration, effectiveness }, updateParams] =
         useMitigation<CommunityMitigationParamsExport>("community");
     let [params] = useParams();
     let [days] = useDays();
@@ -35,17 +35,17 @@ export function CommunityEditor() {
             </FormGroup>
             <FormGroup>
                 <MiniExpandable
-                    title="Community mitigation rate"
+                    title="Community mitigation effectiveness"
                     initialState={true}
                 >
                     <MatrixInput
-                        value={contact_multiplier}
+                        value={effectiveness}
                         step={0.1}
-                        min={0.5}
-                        max={1.5}
+                        min={0.0}
+                        max={1.0}
                         symmetric={params.population_fraction_labels}
                         onChange={(newVal) => {
-                            updateParams({ contact_multiplier: newVal });
+                            updateParams({ effectiveness: newVal });
                         }}
                     />
                 </MiniExpandable>

--- a/wasm_dynode/src/mitigations.rs
+++ b/wasm_dynode/src/mitigations.rs
@@ -45,7 +45,7 @@ pub struct CommunityMitigationParamsExport {
     pub editable: bool,
     pub start: f64,
     pub duration: f64,
-    pub contact_multiplier: Vec<f64>,
+    pub effectiveness: Vec<f64>,
 }
 
 #[derive(Debug, Clone)]
@@ -54,7 +54,7 @@ pub struct CommunityMitigationParams<const N: usize> {
     pub editable: bool,
     pub start: f64,
     pub duration: f64,
-    pub contact_multiplier: SMatrix<f64, N, N>,
+    pub effectiveness: SMatrix<f64, N, N>,
 }
 
 impl<const N: usize> From<CommunityMitigationParams<N>> for CommunityMitigationParamsExport {
@@ -64,7 +64,7 @@ impl<const N: usize> From<CommunityMitigationParams<N>> for CommunityMitigationP
             editable: value.editable,
             start: value.start,
             duration: value.duration,
-            contact_multiplier: value.contact_multiplier.data.as_slice().into(),
+            effectiveness: value.effectiveness.data.as_slice().into(),
         }
     }
 }
@@ -78,7 +78,7 @@ impl<const N: usize> TryFrom<CommunityMitigationParamsExport> for CommunityMitig
             editable: value.editable,
             start: value.start,
             duration: value.duration,
-            contact_multiplier: SMatrix::from_iterator(value.contact_multiplier.into_iter()),
+            effectiveness: SMatrix::from_iterator(value.effectiveness.into_iter()),
         })
     }
 }
@@ -127,7 +127,7 @@ impl<const N: usize> Default for MitigationParams<N> {
                 editable: true,
                 start: 60.0,
                 duration: 20.0,
-                contact_multiplier: SMatrix::from_element(1.0),
+                effectiveness: SMatrix::from_element(0.25),
             },
         }
     }

--- a/wasm_dynode/src/model.rs
+++ b/wasm_dynode/src/model.rs
@@ -1,5 +1,5 @@
 use crate::{DynodeModel, ModelOutput, Parameters};
-use nalgebra::{Const, Matrix, MatrixView, SVector, Storage, StorageMut};
+use nalgebra::{Const, Matrix, MatrixView, SMatrix, SVector, Storage, StorageMut};
 use ode_solvers::{Dopri5, System};
 use paste::paste;
 
@@ -210,10 +210,9 @@ impl<const N: usize> System<f64, State<N>> for &SEIRModel<N> {
             && x >= community_params.start
             && x < (community_params.start + community_params.duration)
         {
-            self.parameters
-                .contact_matrix
-                .component_mul(&community_params.contact_multiplier)
-                / self.contact_matrix_normalization
+            self.parameters.contact_matrix.component_mul(
+                &(SMatrix::<f64, N, N>::from_element(1.0) - community_params.effectiveness),
+            ) / self.contact_matrix_normalization
         } else {
             self.parameters.contact_matrix / self.contact_matrix_normalization
         };

--- a/wasm_dynode/src/parameters.rs
+++ b/wasm_dynode/src/parameters.rs
@@ -57,8 +57,8 @@ impl Default for Parameters<2> {
             death_delay: 10.0,
             mitigations: {
                 let mut default = MitigationParams::default();
-                default.community.contact_multiplier = matrix![0.5, 1.10;
-                                                               1.10, 1.0];
+                default.community.effectiveness = matrix![0.5, -0.10;
+                                                               -0.10, 0.0];
                 default
             },
         }


### PR DESCRIPTION
- Add documentation
- Update default values (25% effectiveness)
- Rename/refactor from "contact multiplier" to "effectiveness": This will be a more familiar input for most users. In principle, this can be a number in $[-1, 1]$, but in practice, for most cases, people will want to enter values in the range $[0, 1]$, where zero means "no effect" and 1 means "completely extinguishes transmission"

`cargo +nightly test` passed, but I would appreciate review to make sure I didn't mess something up!