### PR TITLE
Update 2-dose vaccination timing system

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,11 +49,12 @@ These compartments currently represent the proportion of the total population $N
     - $\dot{V}_\mathrm{max}$: maximum vaccination rate
     - $V_\mathrm{tot}$: total number of vaccines available
     - $t_V$: start of (first dose) vaccine administration
-    - $\Delta t_{V2}$: delay from $t_V$ before beginning administration of second doses, constrained between 0 and $V_\mathrm{tot} / \dot{V}_\mathrm{max}$
-    - $\mathrm{Frac2Dose}$: fraction of all doses set aside as second doses, constrained between 0 and $1 - \Delta t_{V2} V_\mathrm{tot} / \dot{V}_\mathrm{max}$
+    - $\Delta t_{V2}$: delay from $t_V$ before beginning administration of second doses
+    - $p_{V2}$: fraction of all vaccinees who receive 2 doses
     - Derive: $\dot{V}_1(t)$: time-varying first dose administration rate (number of people per time)
     - Derive: $\dot{V}_2(t)$
 - Vaccine efficacy
+    - $\tau_\mathrm{ramp}$: Ramp-up time (delay between vaccination and protection)
     - $\mathrm{VE}_S$: efficacy against infection (i.e., being infected)
     - $\mathrm{VE}_I$: efficacy against transmission given infection
     - $\mathrm{VE}_{P,Y|I}$: efficacy against symptoms given infection.
@@ -85,28 +86,28 @@ These compartments currently represent the proportion of the total population $N
 
 ### Equations
 
-Let $f(A, B)$ be the flux from compartment $A$ to $B$.
+Let $f(t, A, B)$ be the flux from compartment $A$ to $B$ at time $t$.
 
 #### Vaccination
 
-The time-varying, first-dose vaccination rate is equals $\dot{V}_\mathrm{max}$ until second doses begin to be administered, then decreases to a new rate, until doses are exhausted:
+Assume that first dose vaccination begins at some rate, continues at that rate, then stops. Second dose vaccinations occur in a similar block, delayed in time. Rates of first and second dose administration are such that, if the two vaccination blocks overlapped, they would hit the maximum rate.
+
+First derive the duration $T = \dot{V}_\mathrm{max} / V_\mathrm{tot}$ of each vaccination block.
 
 ```math
 \dot{V}_1(t) = \begin{cases}
-0 & t < t_V \\
-\dot{V}_\mathrm{max} & t_V \leq t < t_V + \Delta t_{V2} \\
-\left(1 - \frac{\mathrm{Frac2Dose}}{1 - \Delta t_{V2} / t_\mathrm{end}} \right) \dot{V}_\mathrm{max} & t_V + \Delta t_{V2} \leq t < t_\mathrm{end} \\
-0 & t \geq t_\mathrm{end}
+\frac{\dot{V}_\mathrm{max}}{1 + p_{V2}} & t_V \leq t < t_V + T \\
+0 & \text{otherwise}
 \end{cases}
 ```
 
-where $t_\mathrm{end} = V_\mathrm{tot} / \dot{V}_\mathrm{max}$. The second-dose rate is:
+The second-dose rate is:
 
 ```math
 \dot{V}_2(t) = \begin{cases}
-0 & t < t_V + \Delta t_{V2} \\
-\frac{\mathrm{Frac2Dose}}{1 - \Delta t_{V2} / t_\mathrm{end}} \dot{V}_\mathrm{max} & t_V + \Delta t_{V2} \leq t < t_\mathrm{end} \\
-0 & t \geq t_\mathrm{end}
+\frac{p_{V2}}{1 + p_{V2}} \dot{V}_\mathrm{max} & t_V + \Delta t_{V2}
+\leq t < t_V + \Delta t_{V2} + T \\
+0 & \text{otherwise}
 \end{cases}
 ```
 
@@ -114,17 +115,12 @@ The flux into the vaccine-protected compartments are:
 
 ```math
 \begin{align*}
-f(\mathrm{SU}_i, \mathrm{SV}_i) &= \frac{\mathrm{SU}}{\mathrm{SU} + \mathrm{EU} + \mathrm{IU} + \mathrm{RU}} \frac{N_i}{N} \dot{V}_1 \\
-f(\mathrm{SV}_i, \mathrm{S2V}_i) &= \frac{\mathrm{SV}}{\mathrm{SV} + \mathrm{EV} + \mathrm{IV} + \mathrm{RV}} \frac{N_i}{N} \dot{V}_2
+f(t, \mathrm{SU}_i, \mathrm{SV}_i) &= \frac{\mathrm{SU}}{\mathrm{SU} + \mathrm{EU} + \mathrm{IU} + \mathrm{RU}} \frac{N_i}{N} \dot{V}_1(t - \tau_\mathrm{ramp}) \\
+f(t, \mathrm{SV}_i, \mathrm{S2V}_i) &= \frac{\mathrm{SV}}{\mathrm{SV} + \mathrm{EV} + \mathrm{IV} + \mathrm{RV}} \frac{N_i}{N} \dot{V}_2(t - \tau_\mathrm{ramp})
 \end{align*}
 ```
 
-Individuals keep their vaccine protection status $\mathrm{V}$ or $\mathrm{2V}$ as they transition from $S$ to $E$, $I$, and $R$.
-
-Note that this approach makes two major assumptions:
-
-- The number of individuals in ramp-up periods or infected during the ramp-up is negligible. We do not count those individuals in the denominator number of individuals eligible for vaccination.
-- Individuals who were infected without vaccine protection never cease to demand first-dose vaccines, and those who were infected with a single dose of protection never cease to demand second doses. In other words, vaccines flow into the $\mathrm{EU}$/$\mathrm{IU}$/$\mathrm{RU}$ compartments, but those compartments never leave the denominator of eligibles.
+Vaccines only provide protection if the ramp-up period completes before infection/exposure. Thus, individuals keep their vaccine protection status (U, V, or 2V) as they transition from $S$ to $E$, $I$, and $R$.
 
 #### Transmission
 

--- a/src/config/parameters.config.ts
+++ b/src/config/parameters.config.ts
@@ -127,7 +127,21 @@ export const ParameterEditorConfig = defineEditorConfig<Parameters>({
     },
     "mitigations.vaccine.administration_rate": {
         label: "Vaccine administration rate",
-        tooltip: "Number of doses administered per day",
+        tooltip: "Maximum number of doses administered per day",
+    },
+    "mitigations.vaccine.ramp_up": {
+        label: "Ramp-up period",
+        tooltip: "Time from vaccination to achieving protection from vaccination, in days. " +
+          "Individuals infected before the ramp-up period is complete have no protection from vaccination."
+    },
+    "mitigations.vaccine.dose2_delay": {
+        label: "Delay between doses",
+        tooltip: "Time that a person must wait before receiving their second dose, in days",
+    },
+    "mitigations.vaccine.p_get_2_doses": {
+        label: "Fraction of vaccinees who receive 2 doses",
+        tooltip:
+            "Of people who receive a first dose, the proportion that also receive a second dose",
     },
     "mitigations.vaccine.ve_s": {
         label: "Vaccine effectiveness against infection",

--- a/src/mitigations/Vaccine.tsx
+++ b/src/mitigations/Vaccine.tsx
@@ -85,28 +85,40 @@ export function VaccineEditor() {
             {params.doses === 2 && (
                 <>
                     <FormGroup>
-                        <label>Delay to second dose campaign</label>
                         <NumberInput
+                            parameter="mitigations.vaccine.ramp_up"
+                            range
+                            min={0}
+                            max={30}
+                            value={params.ramp_up}
+                            onValue={(ramp_up) => updateParams({ ramp_up })}
+                        />
+                    </FormGroup>
+                    <FormGroup>
+                        <NumberInput
+                            parameter="mitigations.vaccine.dose2_delay"
                             range
                             min={0}
                             max={days}
-                            value={params.start2_delay}
-                            onValue={(start2_delay) =>
-                                updateParams({ start2_delay })
+                            value={params.dose2_delay}
+                            onValue={(dose2_delay) =>
+                                updateParams({ dose2_delay })
                             }
                         />
                     </FormGroup>
                     <FormGroup>
-                        <label>
-                            Fraction of all doses that are second doses
-                        </label>
                         <NumberInput
+                            parameter="mitigations.vaccine.p_get_2_doses"
                             range
                             min={0}
-                            max={100}
-                            value={params.fraction_2 * 100}
-                            onValue={(fraction_2) =>
-                                updateParams({ fraction_2: fraction_2 / 100 })
+                            step={0.01}
+                            max={1}
+                            value={params.p_get_2_doses}
+                            numberType="pct"
+                            onValue={(p_get_2_doses) =>
+                                updateParams({
+                                    p_get_2_doses: p_get_2_doses,
+                                })
                             }
                         />
                     </FormGroup>

--- a/src/plots/MitigationPlot.tsx
+++ b/src/plots/MitigationPlot.tsx
@@ -295,9 +295,18 @@ function getAnnotations({
     if (vaccine.enabled) {
         // TODO off by 1?
         const startX = vaccine.start + 1;
-        const endX = Math.ceil(
-            startX + vaccine.doses_available / vaccine.administration_rate
-        );
+        let endX = 0.0;
+
+        if (vaccine.doses === 1 || vaccine.p_get_2_doses === 0.0) {
+            endX = Math.ceil(
+                startX + vaccine.doses_available / vaccine.administration_rate
+            );
+        } else if (vaccine.doses === 2 && vaccine.p_get_2_doses > 0.0) {
+            endX =  Math.ceil(
+                startX + vaccine.dose2_delay + vaccine.doses_available / vaccine.administration_rate
+            );
+        }
+
         tryAddAnnotation(
             startX,
             endX,

--- a/wasm_dynode/src/mitigations.rs
+++ b/wasm_dynode/src/mitigations.rs
@@ -20,14 +20,15 @@ pub struct VaccineParams {
     pub doses: usize,
     // start time of vaccine rollout
     pub start: f64,
-    // delay between start of rollout (of first doses) and when second doses start
-    pub start2_delay: f64,
-    // fraction of doses that are second doses
-    pub fraction_2: f64,
+    // delay between first and second doses
+    pub dose2_delay: f64,
+    // fraction of vaccinees that get a second dose
+    pub p_get_2_doses: f64,
     // maximum vaccine administration rate
     pub administration_rate: f64,
     // total number of vaccine doses available
     pub doses_available: f64,
+    pub ramp_up: f64,
     // vaccine effectiveness: first dose
     pub ve_s: f64,
     pub ve_i: f64,
@@ -137,12 +138,12 @@ impl<const N: usize> Default for MitigationParams<N> {
                 enabled: false,
                 editable: true,
                 doses: 1,
+                dose2_delay: 30.0,
                 start: 0.0,
-                start2_delay: 30.0,
-                // note that fraction_2 value does not matter if doses=1
-                fraction_2: 0.25,
+                p_get_2_doses: 0.9,
                 administration_rate: 1_500_000.0,
                 doses_available: 40_000_000.0,
+                ramp_up: 14.0,
                 ve_s: 0.5,
                 ve_i: 0.5,
                 ve_p: 0.5,

--- a/wasm_dynode/src/model.rs
+++ b/wasm_dynode/src/model.rs
@@ -181,38 +181,50 @@ fn _distribute_initials1(n: f64, i0: f64, r0: f64) -> (f64, f64, f64) {
 }
 
 /// Allocate a vaccine administration rate into first and second doses. Administration
-/// can occur at most at `max_rate` (doses per unit time). Starting at `t_start`,
-/// vaccines are administered at that rate, until `doses_available` is exhausted.
-/// At `start2_delay` after `t_start`, administration is split between first and second
-/// doses such that `fraction_2` of all doses are second doses.
+/// can occur at most at `max_rate` (doses per unit time). Starting at `t_start`, first
+/// doses are administered. After `dose2_delay`, second dose administration begins.
+/// Rates of administration are such that first doses and second doses are administered
+/// for the same amount of time, and the rates add up to satisfy `max_rate` and
+/// `p_get_2_doses`, the proportion of vaccinees who get 2 doses.
+///
+/// Return a tuple (`rate1`, `rate2`) of the rates of first and second dose
+/// administrations at time `t`.
 fn vaccine_rates_by_dose(
     t: f64,
     max_rate: f64,
     t_start: f64,
-    start2_delay: f64,
-    fraction_2: f64,
+    dose2_delay: f64,
+    p_get_2_doses: f64,
     doses_available: f64,
 ) -> (f64, f64) {
-    let duration = doses_available / max_rate;
-    let t_end = t_start + duration;
-    let t_start2 = t_start + start2_delay;
-    // this clamp is a kludge: in fact this error should be caught at the UI level
-    let rate_frac = (fraction_2 / (1.0 - start2_delay / duration))
-        .max(0.0)
-        .min(1.0);
-
     assert!(max_rate >= 0.0);
+    assert!(dose2_delay >= 0.0);
+    assert!((0.0..=1.0).contains(&p_get_2_doses));
     assert!(doses_available >= 0.0);
-    assert!(start2_delay >= 0.0);
-    assert!(0.0 <= rate_frac && rate_frac <= 1.0);
 
-    if t_start <= t && t < t_start2 && t < t_end {
-        (max_rate, 0.0)
-    } else if t_start2 <= t && t < t_end {
-        (max_rate * (1.0 - rate_frac), max_rate * rate_frac)
-    } else {
-        (0.0, 0.0)
-    }
+    let duration = doses_available / max_rate;
+
+    let t_start1 = t_start;
+    let t_end1 = t_start1 + duration;
+    let t_start2 = t_start1 + dose2_delay;
+    let t_end2 = t_start2 + duration;
+
+    let rate1 = max_rate / (1.0 + p_get_2_doses);
+    let rate2 = rate1 * p_get_2_doses;
+    float_eq::assert_float_eq!(rate1 + rate2, max_rate, abs <= 1e-10);
+
+    (
+        if t_start1 <= t && t < t_end1 {
+            rate1
+        } else {
+            0.0
+        },
+        if t_start2 <= t && t < t_end2 {
+            rate2
+        } else {
+            0.0
+        },
+    )
 }
 
 impl<const N: usize> DynodeModel for SEIRModel<N>
@@ -379,7 +391,7 @@ impl<const N: usize> System<f64, State<N>> for &SEIRModel<N> {
         let (administration_rate, administration_rate2) =
             if vax_params.enabled && vax_params.doses == 1 {
                 vaccine_rates_by_dose(
-                    x,
+                    x - vax_params.ramp_up,
                     vax_params.administration_rate,
                     vax_params.start,
                     0.0,
@@ -388,11 +400,11 @@ impl<const N: usize> System<f64, State<N>> for &SEIRModel<N> {
                 )
             } else if vax_params.enabled && vax_params.doses == 2 {
                 vaccine_rates_by_dose(
-                    x,
+                    x - vax_params.ramp_up,
                     vax_params.administration_rate,
                     vax_params.start,
-                    vax_params.start2_delay,
-                    vax_params.fraction_2,
+                    vax_params.dose2_delay,
+                    vax_params.p_get_2_doses,
                     vax_params.doses_available,
                 )
             } else {
@@ -656,14 +668,15 @@ mod test {
             start: 0.0,
             administration_rate: 1_000_000.0,
             doses_available: 20_000_000.0,
+            ramp_up: 0.0,
             ve_s: 0.5,
             ve_i: 0.5,
             ve_p: 0.5,
             ve_2s: 0.7,
             ve_2i: 0.7,
             ve_2p: 0.7,
-            start2_delay: 0.0,
-            fraction_2: 0.0,
+            dose2_delay: 0.0,
+            p_get_2_doses: 0.0,
         };
 
         let ttiq_params = TTIQParams {
@@ -911,10 +924,11 @@ mod test {
             editable: true,
             doses: 2,
             start: 0.0,
-            start2_delay: 0.0,
-            fraction_2: 0.5,
+            dose2_delay: 0.0,
+            p_get_2_doses: 1.0,
             administration_rate: 1_000_000.0,
             doses_available: 20_000_000.0,
+            ramp_up: 0.0,
             ve_s: 0.50,
             ve_i: 0.50,
             ve_p: 0.50,
@@ -957,10 +971,11 @@ mod test {
             editable: true,
             doses: 2,
             start: 0.0,
-            start2_delay: 0.0,
-            fraction_2: 0.0,
+            dose2_delay: 0.0,
+            p_get_2_doses: 0.0,
             administration_rate: 1_000_000.0,
             doses_available: 20_000_000.0,
+            ramp_up: 0.0,
             ve_s: 0.50,
             ve_i: 0.50,
             ve_p: 0.50,
@@ -973,7 +988,7 @@ mod test {
         let mut params2 = params1.clone();
         let mut vax_params2 = vax_params1.clone();
         vax_params2.doses = 1;
-        vax_params2.fraction_2 = 0.25;
+        vax_params2.p_get_2_doses = 1.0 / 3.0;
         params2.mitigations.vaccine = vax_params2;
 
         let model1 = SEIRModel::new(params1);
@@ -997,23 +1012,54 @@ mod test {
     #[test]
     fn test_vax_rate_by_dose() {
         // before vaccination starts, no rates
-        let (rate1, rate2) = vaccine_rates_by_dose(0.0, 1.0, 1.0, 0.0, 0.5, 10.0);
+        let (rate1, rate2) = vaccine_rates_by_dose(0.0, 1.0, 1.0, 0.0, 1.0, 10.0);
         assert_float_eq!(rate1, 0.0, abs <= 1e-6);
         assert_float_eq!(rate2, 0.0, abs <= 1e-6);
 
         // when it's only first dose, all rate should be there
-        let (rate1, rate2) = vaccine_rates_by_dose(0.0, 1.0, 0.0, 1.0, 0.5, 10.0);
+        let (rate1, rate2) = vaccine_rates_by_dose(0.0, 1.0, 0.0, 1.0, 0.0, 10.0);
         assert_float_eq!(rate1, 1.0, abs <= 1e-6);
         assert_float_eq!(rate2, 0.0, abs <= 1e-6);
 
         // if both start at the same time, just split
-        let (rate1, rate2) = vaccine_rates_by_dose(0.0, 1.0, 0.0, 0.0, 0.5, 10.0);
+        let (rate1, rate2) = vaccine_rates_by_dose(0.0, 1.0, 0.0, 0.0, 1.0, 10.0);
         assert_float_eq!(rate1, 0.5, abs <= 1e-6);
         assert_float_eq!(rate2, 0.5, abs <= 1e-6);
 
+        let (rate1, rate2) = vaccine_rates_by_dose(0.1, 1.0, 0.0, 0.0, 0.9, 10.0);
+        assert_float_eq!(rate1, 1.0 / 1.9, abs <= 1e-6);
+        assert_float_eq!(rate2, 0.9 * 1.0 / 1.9, abs <= 1e-6);
+
         // if 2nd dose starts later, it needs a certain rate
-        let (rate1, rate2) = vaccine_rates_by_dose(7.5, 1.0, 0.0, 5.0, 0.25, 10.0);
+        let (rate1, rate2) = vaccine_rates_by_dose(7.5, 1.0, 0.0, 5.0, 1.0, 10.0);
         assert_float_eq!(rate1, 0.5, abs <= 1e-6);
         assert_float_eq!(rate2, 0.5, abs <= 1e-6);
+    }
+
+    #[test]
+    fn test_ramp_up() {
+        // ramp up is equivalent to starting the campaign later
+        let mut params1 = Parameters::default();
+        let mut vax_params1 = params1.mitigations.vaccine.clone();
+        vax_params1.enabled = true;
+        vax_params1.start = 0.0;
+        vax_params1.ramp_up = 14.0;
+        params1.mitigations.vaccine = vax_params1;
+
+        let mut params2 = Parameters::default();
+        let mut vax_params2 = vax_params1.clone();
+        vax_params2.enabled = true;
+        vax_params2.start = 14.0;
+        vax_params2.ramp_up = 0.0;
+        params2.mitigations.vaccine = vax_params2;
+
+        let model1 = SEIRModel::new(params1);
+        let model2 = SEIRModel::new(params2);
+
+        let sim_duration = 300;
+        let results1 = TestResults::new(&model1.parameters, &model1.integrate(sim_duration));
+        let results2 = TestResults::new(&model2.parameters, &model2.integrate(sim_duration));
+
+        assert_float_eq!(results1.attack_rate, results2.attack_rate, abs <= 1e-10);
     }
 }


### PR DESCRIPTION
- Use flu-models-like vaccination campaign rate & timing system
  - Assume rates add up to maximum rate, then push the second dose block later in time
  - This avoids any need for feedback in parameter input UI
- Add ramp-up period (ie delay from vaccination to protection)
- Adjust the vaccine campaign timing display bar to account for 1 vs. 2 doses

Resolves #54 
Resolves #30 