### PR TITLE
Add rollup dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 - Install [node](https://nodejs.org/en/download)
 - Run model tests: `cargo test`
 - Install frontend: `npm install`
-    - Because of platform differences, you may need to delete `node_modules` and `package-lock.json` and run `npm install` again: `rm -rf package-lock.json node_modules/ && npm install`
 - Run frontend tests: `npm run test`
 - Compile the model to Web Assembly: `npm run wasm`
 - Run the frontend: `npm run dev`

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,9 @@
                 "vite-plugin-top-level-await": "^1.5.0",
                 "vite-plugin-wasm": "^3.4.1",
                 "vitest": "^3.0.9"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-linux-x64-gnu": "4.35.0"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -1074,6 +1077,19 @@
             "optional": true,
             "os": [
                 "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.35.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.35.0.tgz",
+            "integrity": "sha512-Pim1T8rXOri+0HmV4CdKSGrqcBWX0d1HoPnQ0uw0bdp1aP5SdQVNBy8LjYncvnLgu3fnnCt17xjWGd4cqh8/hA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
             ]
         },
         "node_modules/@swc/core": {

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
         "vite-plugin-top-level-await": "^1.5.0",
         "vite-plugin-wasm": "^3.4.1",
         "vitest": "^3.0.9"
+    },
+    "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "4.35.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
         "build:azure": "npm run build -- --mode azure",
         "prettier": "prettier",
         "lint": "eslint .",
-        "test": "vitest",
-        "test_run": "vitest run",
+        "test": "vitest run",
         "coverage": "vitest --coverage",
         "check": "npm run wasm && cargo test && npm run lint && npm run build && npm run test -- --no-watch",
         "preview": "vite preview"


### PR DESCRIPTION
- Add an optional dependency so this builds in WSL. Cf. https://github.com/npm/cli/issues/4828
- Move from plain `vitest` (which seems to be equivalent to `vitest watch`) to `vitest run`, which you can add `--watch` to if you want

I think this resolves the problems previously seen in #60 and #69